### PR TITLE
Update ganalytics.php

### DIFF
--- a/classes/api/ganalytics.php
+++ b/classes/api/ganalytics.php
@@ -33,7 +33,7 @@ defined('MOODLE_INTERNAL') || die();
 
 class ganalytics extends analytics {
     public static function insert_tracking() {
-        global $CFG;
+        global $CFG, $OUTPUT;
 
         $template = new stdClass();
         $template->analyticsid = get_config('local_analytics', 'analyticsid');


### PR DESCRIPTION
Declared global variable $OUTPUT to insert_tracking function since I was receiving an " Undefined variable: OUTPUT" error when using this plugin with moodle version 3.2.2