### PR TITLE
Site header passing format_string.

### DIFF
--- a/classes/api/ganalytics.php
+++ b/classes/api/ganalytics.php
@@ -33,7 +33,7 @@ defined('MOODLE_INTERNAL') || die();
 
 class ganalytics extends analytics {
     public static function insert_tracking() {
-        global $CFG;
+        global $CFG, $OUTPUT;
 
         $template = new stdClass();
         $template->analyticsid = get_config('local_analytics', 'analyticsid');

--- a/classes/api/guniversal.php
+++ b/classes/api/guniversal.php
@@ -44,7 +44,7 @@ class guniversal extends analytics {
         if ($cleanurl) {
             $template->addition = "{'hitType' : 'pageview',
                 'page' : '".self::trackurl(true, true)."',
-                'title' : '".addslashes($PAGE->heading)."'
+                'title' : '".addslashes(format_string($PAGE->heading))."'
                 }";
         } else {
             $template->addition = "'pageview'";


### PR DESCRIPTION
When cleanurl is activated and you have multilang in your course categories, e.g. "{mlang de}Informatik{mlang}{mlang fr}Informatique{mlang}{mlang it}Informatica{mlang}{mlang en}Computer Science{mlang}{mlang es}Informática{mlang}" then the results in Piwik are displayed with all those multilang tags as well.
This is circumvented if site titles pass through format_string.