### PR TITLE
Analytics Code Present When Not Enabled

### DIFF
--- a/classes/api/ganalytics.php
+++ b/classes/api/ganalytics.php
@@ -39,7 +39,7 @@ class ganalytics extends analytics {
         $template->analyticsid = get_config('local_analytics', 'analyticsid');
         $cleanurl = get_config('local_analytics', 'cleanurl');
 
-        if (self::should_track()) {
+        if (self::should_track() && !empty($template->analyticsid)) {
             if ($cleanurl) {
                 $template->page = self::trackurl(true, true);
             }

--- a/classes/api/guniversal.php
+++ b/classes/api/guniversal.php
@@ -50,7 +50,7 @@ class guniversal extends analytics {
             $template->addition = "'pageview'";
         }
 
-        if (self::should_track()) {
+        if (self::should_track() && !empty($template->analyticsid)) {
             $script = $OUTPUT->render_from_template('local_analytics/guniversal', $template);
         }
     }

--- a/classes/injector.php
+++ b/classes/injector.php
@@ -46,9 +46,12 @@ class injector {
 
         $engine = null;
 
-        $analytics = get_config('local_analytics', 'analytics');
+        $analyticsenabled = get_config('local_analytics', 'enabled');
+        if (!$analyticsenabled) {
+            return;
+        }
+
         $analyticstypes = array('guniversal', 'ganalytics', 'piwik');
-        
         foreach ($analyticstypes as $type) {
             $enabled = get_config('local_analytics', $type);
             if ($enabled) {


### PR DESCRIPTION
- Correctly check the ``enabled`` setting to see if we should be doing anything at all.
- For both Google Analytics options, only inject script when ``analyticsid`` is not empty.