### PR TITLE
Piwik/Matomo integration is broken for Moodle 3+

### DIFF
--- a/templates/piwik.mustache
+++ b/templates/piwik.mustache
@@ -41,7 +41,7 @@
 </noscript>
 {{/imagetrack}}
 <script type="text/javascript">
-var _paq = _paq || [];
+window._paq = window._paq || [];
 {{{doctitle}}}
 {{#userid}}
 _paq.push(['setUserId', {{{userid}}}]);


### PR DESCRIPTION
Newer versions of Moodle (from 2.9 onwards) use RequireJS, which executes all plugin JavaScript-snippets within a functions. So a variable declaration like `var _paq` ends up being a local variable, rather than a global variable on `window`, which breaks the Piwik/Matomo integration altogether.