### PR TITLE
Replace all injections by Moodle 3.3+'s before_footer callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ moodle-local_analytics
 
 Release notes:
 
+version: 2019070800
+
+- Replace all injections by Moodle 3.3+'s `before_footer` callback
+
+It now depends on at least Moodle 3.3.
+
 version: 2018092400
 
 - Fixing unit test "provider_testcase" privacy/tests/provider_test.php

--- a/lib.php
+++ b/lib.php
@@ -31,48 +31,10 @@ use local_analytics\injector;
 
 require_once(__DIR__.'/../../config.php');
 
-
 /**
- * Used since Moodle 29.
- */
-function local_analytics_extend_navigation() {
-    injector::inject();
-}
-
-/**
- * Used since Moodle 29.
- */
-function local_analytics_extend_settings_navigation() {
-    injector::inject();
-}
-
-/**
- * Used in Moodle 30+ when a user is logged on.
- */
-function local_analytics_extend_navigation_user_settings() {
-    injector::inject();
-}
-
-/**
- * Used in Moodle 30+ on the frontpage.
- */
-function local_analytics_extend_navigation_frontpage() {
-    injector::inject();
-}
-
-/**
- * Used in Moodle 31+ when a user is logged on.
- */
-function local_analytics_extend_navigation_user() {
-    injector::inject();
-}
-
-/**
- * Proposed in MDL-53978.
+ * Output callback, available since Moodle 3.3
  *
- * We are not using all callbacks provided there because the one below would cover all cases.
- * If approved, this would be the only needed callback, the others would provide legacy support.
  */
-function tool_callbacktest_before_http_headers() {
+function local_analytics_before_footer() {
     injector::inject();
 }

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2018092400;
+$plugin->version  = 2019070800;
 $plugin->requires = 2017051500;
-$plugin->release = '1.6 (Build: 2018092400)';
+$plugin->release = '1.7 (Build: 2019070800)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_analytics';

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version  = 2018092400;
-$plugin->requires = 2011033010;
+$plugin->requires = 2017051500;
 $plugin->release = '1.6 (Build: 2018092400)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_analytics';


### PR DESCRIPTION
This:
- makes local_analytics only work on Moodle 3.3+ (but all older Moodle releases got out of security support in May 2019)
- simplifies the injection entry points to just the only right one
- removes a very special bug: this injection caused the navigation to get broken on format_singleactivity with mod_book for non-admins: the mod/book/view.php pages would get no blocks at all.