### PR TITLE
Fix issue with upgrade script using incorrect db method

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -82,9 +82,7 @@ function xmldb_local_analytics_upgrade($oldversion) {
 
     if ($oldversion < 2019070801) {
         // Remove 'analytics' from the configuration table.
-        if ($analytics = $DB->get_record('config_plugins', array('plugin' => 'local_analytics', 'name' => 'analytics')) ) {
-            $DB->delete_record('config_plugins', $analytics);
-        }
+        $DB->delete_records('config_plugins', ['plugin' => 'local_analytics', 'name' => 'analytics']);
         upgrade_plugin_savepoint(true, 2019070801, 'local', 'analytics');
     }
 


### PR DESCRIPTION
This patch fixes issue #29 with upgrade script using non-existant database method `delete_record` which is causing upgrade to fail with error:
```
Default exception handler: Exception - Call to undefined method pgsql_read_slave_native_moodle_database::delete_record() Debug: 
Error code: generalexceptionmessage
* line 86 of /local/analytics/db/upgrade.php: Error thrown
* line 644 of /lib/upgradelib.php: call to xmldb_local_analytics_upgrade()
* line 1869 of /lib/upgradelib.php: call to upgrade_plugins()
* line 193 of /admin/cli/upgrade.php: call to upgrade_noncore()
```