### PR TITLE
Also inject analytics with headers, not just in footer

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -37,3 +37,11 @@ use local_analytics\injector;
 function local_analytics_before_footer() {
     injector::inject();
 }
+
+/**
+ * Output callback, available since Moodle 3.3
+ *
+ */
+function local_analytics_before_http_headers() {
+    injector::inject();
+}


### PR DESCRIPTION
The current before_footer hook works great for Google Analytics,
but isn't 100% consistent for Piwik as usually the page has
often rendered the header by that time.

Fixes #33 