### PR TITLE
40 pagetitle

### DIFF
--- a/classes/api/guniversal.php
+++ b/classes/api/guniversal.php
@@ -52,7 +52,7 @@ class guniversal extends analytics {
         if ($cleanurl) {
             $template->addition = "{'hitType' : 'pageview',
                 'page' : '".self::trackurl(true, true)."',
-                'title' : '".addslashes(format_string($PAGE->heading))."'
+                'title' : '".addslashes($PAGE->title)."'
                 }";
         } else {
             $template->addition = "'pageview'";

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -21,25 +21,17 @@
  * Currently support Google Analytics and Piwik
  *
  * @package    local_analytics
- * @copyright  Bas Brands, Sonsbeekmedia 2017
- * @author     Bas Brands <bas@sonsbeekmedia.nl>, David Bezemer <info@davidbezemer.nl>
+ * @copyright  2024 Leon Stringer <leon.stringer@ntlworld.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use local_analytics\injector;
-
-/**
- * Output callback, available since Moodle 3.3
- *
- */
-function local_analytics_before_footer() {
-    injector::inject();
-}
-
-/**
- * Output callback, available since Moodle 3.3
- *
- */
-function local_analytics_before_http_headers() {
-    injector::inject();
-}
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_http_headers::class,
+        'callback' => [\local_analytics\injector::class, 'inject'],
+    ],
+    [
+        'hook' => \core\hook\output\before_standard_footer_html_generation::class,
+        'callback' => [\local_analytics\injector::class, 'inject'],
+    ],
+];

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2023061400;
-$plugin->requires = 2017051500;
-$plugin->release = '1.7 (Build: 2019070800)';
+$plugin->version  = 2024070200;
+$plugin->requires = 2024042200; // Moodle 4.4
+$plugin->release = '1.8 (Build: 2024070200)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_analytics';


### PR DESCRIPTION
Proposed fix for #40 

I've used `$PAGE->title` for the 'title' property. For a course section page with edit mode enabled this has a value like "Edit Section: New section | My first course | Test Site". I've dropped the use of `format_string()` as surely (!) `$PAGE->title` doesn't need any filters applying.